### PR TITLE
Create a smaller, smarter dependency tree during build

### DIFF
--- a/src/document-parser.ts
+++ b/src/document-parser.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {DocumentDescriptor} from 'hydrolysis';
+import {posix as posixPath} from 'path';
+import {Node, queryAll, predicates, getAttribute} from 'dom5';
+
+export interface DocumentDeps {
+  imports?: Array<string>;
+  scripts?: Array<string>;
+  styles?: Array<string>;
+}
+
+function collectScriptsAndStyles(tree: DocumentDescriptor): DocumentDeps {
+  let scripts: string[] = [];
+  let styles: string[] = [];
+  tree.html.script.forEach((script: Node) => {
+    // TODO(justinfagnani): stop patching Nodes in Hydrolysis
+    let __hydrolysisInlined = (<any>script).__hydrolysisInlined;
+    if (__hydrolysisInlined) {
+      scripts.push(__hydrolysisInlined);
+    }
+  });
+  tree.html.style.forEach((style: Node) => {
+    let href = getAttribute(style, 'href');
+    if (href) {
+      styles.push(href);
+    }
+  });
+  return {
+    scripts,
+    styles
+  };
+}
+
+export function getDependenciesFromDocument(descriptor: DocumentDescriptor, dir: string): DocumentDeps {
+  let allHtmlDeps: string[] = [];
+  let allScriptDeps = new Set<string>();
+  let allStyleDeps = new Set<string>();
+
+  let deps: DocumentDeps = collectScriptsAndStyles(descriptor);
+  deps.scripts.forEach((s) => allScriptDeps.add(posixPath.resolve(dir, s)));
+  deps.styles.forEach((s) => allStyleDeps.add(posixPath.resolve(dir, s)));
+  if (descriptor.imports) {
+    let queue = descriptor.imports.slice();
+    while (queue.length > 0) {
+      let next = queue.shift();
+      if (!next.href) {
+        continue;
+      }
+      allHtmlDeps.push(next.href);
+      let childDeps = getDependenciesFromDocument(next, posixPath.dirname(next.href));
+      allHtmlDeps = allHtmlDeps.concat(childDeps.imports);
+      childDeps.scripts.forEach((s) => allScriptDeps.add(s));
+      childDeps.styles.forEach((s) => allStyleDeps.add(s));
+    }
+  }
+
+  return {
+    scripts: Array.from(allScriptDeps),
+    styles: Array.from(allStyleDeps),
+    imports: allHtmlDeps,
+  };
+}

--- a/src/polymer-project.ts
+++ b/src/polymer-project.ts
@@ -15,11 +15,11 @@ import * as logging from 'plylog';
 import {Transform, Readable} from 'stream';
 import File = require('vinyl');
 import * as vfs from 'vinyl-fs';
-
 import {StreamAnalyzer} from './analyzer';
 import {Bundler} from './bundle';
 import {optimize, OptimizeOptions} from './optimize';
-import {FileCB} from './streams';
+import {FileCB, SourceDependenciesStream, VinylHydrateStream} from './streams';
+import * as gulpif from 'gulp-if';
 
 const logger = logging.getLogger('polymer-project');
 const pred = dom5.predicates;
@@ -62,20 +62,17 @@ export interface ProjectOptions {
   sourceGlobs?: string[];
 
   /**
-   * List of glob patterns, relative to root, of dependencies to read from the
-   * file system. For example node_modules\/**\/* and bower_components\/**\/*
+   * List of file paths, relative to the project directory, that should be included
+   * as dependencies in the build target.
    */
-  dependencyGlobs?: string[];
+  includeDependencies?: string[];
 }
 
 export const defaultSourceGlobs = [
-  '**/*',
-  '!build/**/*',
-];
-
-export const defaultDependencyGlobs = [
-  'bower_components/**/*',
-  'node_modules/**/*',
+  'src/**/*',
+  // NOTE(fks) 06-29-2016: `polymer-cli serve` uses a bower.json file to display
+  // information about the project. The file is included here by default.
+  'bower.json',
 ];
 
 function resolveGlob(fromPath: string, glob: string) {
@@ -105,7 +102,7 @@ export class PolymerProject {
   shell: string;
   fragments: string[];
   sourceGlobs: string[];
-  dependencyGlobs: string[];
+  includeDependencies: string[];
 
   _splitFiles: Map<string, SplitFile> = new Map();
   _parts: Map<string, SplitFile> = new Map();
@@ -119,9 +116,9 @@ export class PolymerProject {
     this.fragments = (options.fragments || [])
         .map((f) => osPath.resolve(this.root, f));
     this.sourceGlobs = (options.sourceGlobs || defaultSourceGlobs)
-        .map((g) => resolveGlob(this.root, g));
-    this.dependencyGlobs = (options.dependencyGlobs || defaultDependencyGlobs)
-        .map((g) => resolveGlob(this.root, g));
+        .map((glob) => resolveGlob(this.root, glob));
+    this.includeDependencies = (options.includeDependencies || [])
+        .map((path) => osPath.resolve(this.root, path));
 
     this._analyzer = new StreamAnalyzer(
       this.root,
@@ -141,12 +138,12 @@ export class PolymerProject {
     logger.debug(`entrypoint: ${this.entrypoint}`);
     logger.debug(`fragments: ${this.entrypoint}`);
     logger.debug(`sources: ${this.sourceGlobs}`);
-    logger.debug(`dependencies: \n\t${this.dependencyGlobs}`);
+    logger.debug(`includeDependencies: ${this.includeDependencies}`);
   }
 
   /**
    * An array of globs composed of `entrypoint`, `shell`, `fragments`,
-   * `sourceGlobs`, and the inverted array of `dependencyGlobs`.
+   * `sourceGlobs`.
    */
   get allSourceGlobs(): string[] {
     let globs: string[] = [];
@@ -157,11 +154,6 @@ export class PolymerProject {
     }
     if (this.sourceGlobs && this.sourceGlobs.length > 0) {
       globs = globs.concat(this.sourceGlobs);
-    }
-    if (this.dependencyGlobs && this.dependencyGlobs.length > 0) {
-      let excludes = this.dependencyGlobs.map((g) => invertGlob(g));
-      logger.debug(`excludes: \n\t${excludes.join('\n\t')}`);
-      globs = globs.concat(excludes);
     }
     logger.debug(`sourceGlobs: \n\t${globs.join('\n\t')}`);
     return globs;
@@ -181,17 +173,24 @@ export class PolymerProject {
     });
   }
 
-  // TODO(justinfagnani): add options, pass to vfs.src()
   dependencies(): NodeJS.ReadableStream {
-    let deps = this.dependencyGlobs;
-    return vfs.src(deps, {
-      allowEmpty: true,
-      cwdbase: true,
-      nodir: true,
-    });
-  }
+    let stream: any = this.sources();
+    stream = stream.pipe(new SourceDependenciesStream(this.allSourceGlobs));
 
-  // TODO(justinfagnani): add allFiles()
+    // If we need to include additional dependencies, create a new vfs.src
+    // stream and pipe our default dependencyStream through it to combine.
+    if (this.includeDependencies.length > 0) {
+      let includeStream = vfs.src(this.includeDependencies, {
+         allowEmpty: true,
+         cwdbase: true,
+         nodir: true,
+         passthrough: true,
+      });
+      stream = stream.pipe(includeStream);
+    }
+
+    return stream.pipe(new VinylHydrateStream());
+  }
 
   /**
    * Returns a new `Transform` that splits inline script into separate files.

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -8,13 +8,26 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+import {posix as posixPath} from 'path';
 import {PassThrough, Readable, Transform} from 'stream';
 import File = require('vinyl');
+import * as fs from 'fs';
+import {Node, getAttribute} from 'dom5';
+import {Analyzer, Loader, FSResolver, DocumentDescriptor} from 'hydrolysis';
 
+import urlFromPath from './url-from-path';
+import {DocumentDeps, getDependenciesFromDocument} from './document-parser';
+
+const minimatchAll = require('minimatch-all');
 const multipipe = require('multipipe');
 
 export type FileCB = (error?: any, file?: File) => void;
 
+export interface DocumentDeps {
+  imports?: Array<string>;
+  scripts?: Array<string>;
+  styles?: Array<string>;
+}
 /**
  * Waits for the given ReadableStream
  */
@@ -41,4 +54,117 @@ export function compose(streams: NodeJS.ReadWriteStream[]) {
   } else {
     return new PassThrough({objectMode: true});
   }
+}
+
+/**
+ * A stream that accepts source file objects from a vinyl stream, and emits
+ * the file paths of all required file dependencies. Useful for building
+ * the dependency tree during build.
+ */
+export class SourceDependenciesStream extends Transform {
+
+  // A set of all dependency file paths passed through the stream
+  sourceGlobs: string[];
+  files = new Set<string>();
+
+  constructor(sourcGlobs: string[]) {
+    super({ objectMode: true });
+    this.sourceGlobs = sourcGlobs;
+  }
+
+  /**
+   * Process the given dependency before pushing it through the stream.
+   * Each dependency is only pushed through once to avoid duplicates.
+   */
+  pushDependency(dependencyPath: string) {
+    // If this is the first time we've seen this dependency, push it through.
+    if (this.files.has(dependencyPath)) {
+      return;
+    }
+
+    if (minimatchAll(dependencyPath, this.sourceGlobs)) {
+      console.log('MATCH SOURCE', dependencyPath);
+      return;
+    }
+
+    this.files.add(dependencyPath);
+    let dependency = new File({ path: dependencyPath });
+    this.push(dependency);
+  }
+
+  _transform(
+    file: File,
+    encoding: string,
+    callback: (error?: Error, data?: File) => void
+  ): void {
+    // If the file has already been seen, it was as the dependency of another
+    // source file. We can assume its dependencies were already parsed then.
+    if (this.files.has(file.path)) {
+      callback();
+      return;
+    }
+
+    // Only HTML source files can have dependencies. If the given file is not
+    // an HTML file, we can assume it has no dependencies.
+    if (file.extname !== '.html') {
+      callback();
+      return;
+    }
+
+    this._getDependencies(file.path).then((allDeps: DocumentDeps) => {
+      allDeps.imports.forEach(this.pushDependency.bind(this));
+      allDeps.scripts.forEach(this.pushDependency.bind(this));
+      allDeps.styles.forEach(this.pushDependency.bind(this));
+      callback();
+    }).catch(err => {
+      callback(err);
+    });
+  }
+
+  /**
+   * Create an analyzer and retreive all transitive dependencies for `url`
+   */
+  _getDependencies(url: string): Promise<DocumentDeps> {
+    let pathDirectory = posixPath.dirname(url);
+    let resolver = new FSResolver({});
+    let loader = new Loader();
+    loader.addResolver(resolver);
+    let analyzer = new Analyzer(false, loader);
+
+    return analyzer.metadataTree(url)
+      .then((tree) => getDependenciesFromDocument(tree, pathDirectory));
+  }
+}
+
+/**
+ * A stream that passes through Vinyl file objects and loads any files
+ * that have not yet had their content loaded.
+ */
+export class VinylHydrateStream extends Transform {
+
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  _transform(
+    file: File,
+    encoding: string,
+    callback: (error?: Error, data?: File) => void
+  ): void {
+    // Don't load a file that already has contents.
+    if (file.contents) {
+      callback(null, file);
+      return;
+    }
+
+    fs.readFile(file.path, (err?: Error, data?: Buffer) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      file.contents = data;
+      callback(null, file);
+    });
+  }
+
 }

--- a/test/polymer-project_test.js
+++ b/test/polymer-project_test.js
@@ -19,70 +19,101 @@ const PolymerProject = require('../lib/polymer-project').PolymerProject;
 
 suite('PolymerProject', () => {
 
-  let project;
+  let defaultProject;
   let root = path.resolve(__dirname, 'test-project');
 
   let unroot = (p) => p.substring(root.length + 1);
 
   setup(() => {
-    project = new PolymerProject({
+    defaultProject = new PolymerProject({
       root: path.resolve(__dirname, 'test-project'),
       entrypoint: 'index.html',
       shell: 'shell.html',
+      sourceGlobs: [
+        'source-dir/**',
+      ],
     });
   })
 
   test('reads sources', (done) => {
     let files = [];
-    project.sources()
+    defaultProject.sources()
       .on('data', (f) => files.push(f))
       .on('end', () => {
         let names = files.map((f) => unroot(f.path));
         let expected = [
           'index.html',
           'shell.html',
-          // note, we'll probably want to exclude certain files by defult in
-          // the future
-          'gulpfile.js',
+          'source-dir/my-app.html',
         ];
         assert.sameMembers(names, expected);
         done();
       });
   });
 
-  test('reads dependencies', (done) => {
-    let files = [];
-    project.dependencies()
-      .on('data', (f) => files.push(f))
-      .on('end', () => {
-        let names = files.map((f) => unroot(f.path));
-        let expected = [
-          'bower_components/dep.html',
-        ];
-        assert.sameMembers(names, expected);
-        done();
+  suite('.dependencies()', () => {
+
+    test('reads dependencies', (done) => {
+      let files = [];
+      defaultProject.dependencies()
+        .on('data', (f) => files.push(f))
+        .on('end', () => {
+          let names = files.map((f) => unroot(f.path));
+          let expected = [
+            'bower_components/dep.html',
+          ];
+          assert.sameMembers(names, expected);
+          done();
+        });
+    });
+
+    test('reads dependencies and includes additionally provided files', (done) => {
+      let files = [];
+      let projectWithIncludedDeps = new PolymerProject({
+        root: path.resolve(__dirname, 'test-project'),
+        entrypoint: 'index.html',
+        shell: 'shell.html',
+        sourceGlobs: [
+          'source-dir/**',
+        ],
+        includeDependencies: [
+          'bower_components/unreachable*',
+        ],
       });
+
+      projectWithIncludedDeps.dependencies()
+        .on('data', (f) => files.push(f))
+        .on('end', () => {
+          let names = files.map((f) => unroot(f.path));
+          let expected = [
+            'bower_components/dep.html',
+            'bower_components/unreachable-dep.html',
+          ];
+          assert.sameMembers(names, expected);
+          done();
+        });
+    });
   });
 
   test('splits and rejoins scripts', (done) => {
     let splitFiles = new Map();
     let joinedFiles = new Map();
-    project.sources()
-      .pipe(project.splitHtml())
+    defaultProject.sources()
+      .pipe(defaultProject.splitHtml())
       .on('data', (f) => splitFiles.set(unroot(f.path), f))
-      .pipe(project.rejoinHtml())
+      .pipe(defaultProject.rejoinHtml())
       .on('data', (f) => joinedFiles.set(unroot(f.path), f))
       .on('end', () => {
         let expectedSplitFiles = [
           'index.html',
           'shell.html_script_0.js',
           'shell.html',
-          'gulpfile.js',
+          'source-dir/my-app.html',
         ];
         let expectedJoinedFiles = [
           'index.html',
           'shell.html',
-          'gulpfile.js',
+          'source-dir/my-app.html',
         ];
         assert.sameMembers(Array.from(splitFiles.keys()), expectedSplitFiles);
         assert.sameMembers(Array.from(joinedFiles.keys()), expectedJoinedFiles);
@@ -115,14 +146,14 @@ suite('PolymerProject', () => {
     });
 
     sourceStream
-      .pipe(project.splitHtml())
+      .pipe(defaultProject.splitHtml())
       .on('data', (file) => {
         // this is what gulp-html-minifier does...
         if (path.sep === '\\' && file.path.endsWith('.html')) {
           file.path = file.path.replace('\\', '/');
         }
       })
-      .pipe(project.rejoinHtml())
+      .pipe(defaultProject.rejoinHtml())
       .on('data', (file) => {
         let contents = file.contents.toString();
         assert.equal(contents, source);

--- a/test/test-project/bower_components/unreachable-dep.html
+++ b/test/test-project/bower_components/unreachable-dep.html
@@ -1,0 +1,1 @@
+<div id="unreachable-dep"></div>

--- a/test/test-project/index.html
+++ b/test/test-project/index.html
@@ -1,1 +1,2 @@
 <link rel="import" href="shell.html">
+<link rel="import" href="source-dir/my-app.html">

--- a/test/test-project/source-dir/my-app.html
+++ b/test/test-project/source-dir/my-app.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "custom_typings/vinyl-fs.d.ts",
     "src/analyzer.ts",
     "src/bundle.ts",
+    "src/document-parser.ts",
     "src/fork-stream.ts",
     "src/optimize.ts",
     "src/polymer-build.ts",


### PR DESCRIPTION
*Note: Tests still in progress, but the code itself has been cleaned up and can be considered ready for review. I'm submitting now to get some early feedback.*

Known limitations:
- [x] Source files can be dependencies of other source files, so those that are will currently come out of both streams. Should they be filtered out of the dependency stream?  ANSWER: Yes!
- [x] Users can only specify single files to be included on top of the dependency tree. Should we add support for globs? Should we add support for including their transitive dependencies as well? ANSWER: Support for globs added, transitive dependency detection can be a future enhancement if enough people ask for it.

/cc @justinfagnani for feedback on limitations and if they need to be prioritized? I think we could release right now without both but I'm not 100% confident in what PSK does and doesn't need.