### PR TITLE
adds smarter dependency stream via new analyzer architecture

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -15,7 +15,7 @@ import {posix as posixPath} from 'path';
 import {Transform} from 'stream';
 import File = require('vinyl');
 import * as logging from 'plylog';
-import urlFromPath from './url-from-path';
+import {urlFromPath} from './path-transformers';
 import {StreamAnalyzer, DepsIndex} from './analyzer';
 import {compose} from './streams';
 
@@ -254,7 +254,7 @@ export class Bundler extends Transform {
   }
 
   _getBundles() {
-    return this.analyzer.analyze.then((indexes) => {
+    return this.analyzer.analyzeDependencies.then((indexes) => {
       let depsToEntrypoints = indexes.depsToFragments;
       let fragmentToDeps = indexes.fragmentToDeps;
       let bundles = new Map<string, string[]>();

--- a/src/get-dependencies-from-document.ts
+++ b/src/get-dependencies-from-document.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {DocumentDescriptor} from 'hydrolysis';
+import {posix as posixPath} from 'path';
+import {Node, queryAll, predicates, getAttribute} from 'dom5';
+
+export interface DocumentDeps {
+  imports?: Array<string>;
+  scripts?: Array<string>;
+  styles?: Array<string>;
+}
+
+function collectScriptsAndStyles(tree: DocumentDescriptor): DocumentDeps {
+  let scripts: string[] = [];
+  let styles: string[] = [];
+  tree.html.script.forEach((script: Node) => {
+    // TODO(justinfagnani): stop patching Nodes in Hydrolysis
+    let __hydrolysisInlined = (<any>script).__hydrolysisInlined;
+    if (__hydrolysisInlined) {
+      scripts.push(__hydrolysisInlined);
+    }
+  });
+  tree.html.style.forEach((style: Node) => {
+    let href = getAttribute(style, 'href');
+    if (href) {
+      styles.push(href);
+    }
+  });
+  return {
+    scripts,
+    styles
+  };
+}
+
+export function getDependenciesFromDocument(descriptor: DocumentDescriptor, dir: string): DocumentDeps {
+  let allHtmlDeps: string[] = [];
+  let allScriptDeps = new Set<string>();
+  let allStyleDeps = new Set<string>();
+
+  let deps: DocumentDeps = collectScriptsAndStyles(descriptor);
+  deps.scripts.forEach((s) => allScriptDeps.add(posixPath.join(dir, s)));
+  deps.styles.forEach((s) => allStyleDeps.add(posixPath.join(dir, s)));
+  if (descriptor.imports) {
+    let queue = descriptor.imports.slice();
+    let next;
+    while (next = queue.shift()) {
+      if (!next.href) {
+        continue;
+      }
+      allHtmlDeps.push(next.href);
+      let childDeps = getDependenciesFromDocument(next, posixPath.dirname(next.href));
+      allHtmlDeps = allHtmlDeps.concat(childDeps.imports);
+      childDeps.scripts.forEach((s) => allScriptDeps.add(s));
+      childDeps.styles.forEach((s) => allStyleDeps.add(s));
+    }
+  }
+
+  return {
+    scripts: Array.from(allScriptDeps),
+    styles: Array.from(allStyleDeps),
+    imports: allHtmlDeps,
+  };
+}

--- a/src/path-transformers.ts
+++ b/src/path-transformers.ts
@@ -38,7 +38,7 @@
 
 import * as path from 'path';
 
-export default function urlFromPath(root: string, filepath: string) {
+export function urlFromPath(root: string, filepath: string) {
   if (!filepath.startsWith(root)) {
     throw new Error(`file path is not in root: ${filepath} (${root})`);
   }
@@ -53,4 +53,19 @@ export default function urlFromPath(root: string, filepath: string) {
 
   // Otherwise, just return the relative path between the two
   return path.relative(root, filepath);
+}
+
+export function pathFromUrl(root: string, url: string) {
+  let isPlatformWin = /^win/.test(process.platform);
+  let filepath: string;
+
+  // On windows systems, convert URL to filesystem path by replacing slashes
+  if (isPlatformWin) {
+    filepath = url.replace(/\//g, '\\');
+  } else {
+    filepath = url;
+  }
+
+  // Otherwise, just return the relative path between the two
+  return path.join(root, url);
 }

--- a/src/prefetch.ts
+++ b/src/prefetch.ts
@@ -116,7 +116,7 @@ export class PrefetchTransform extends Transform {
     if (this.fileMap.size === 0) {
       return done();
     }
-    this.analyzer.analyze.then((depsIndex: DepsIndex) => {
+    this.analyzer.analyzeDependencies.then((depsIndex: DepsIndex) => {
       let fragmentToDeps = new Map(depsIndex.fragmentToDeps);
 
       if (this.entrypoint && this.shell) {

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -10,6 +10,7 @@
 
 import {PassThrough, Readable, Transform} from 'stream';
 import File = require('vinyl');
+import * as fs from 'fs';
 
 const multipipe = require('multipipe');
 
@@ -41,4 +42,33 @@ export function compose(streams: NodeJS.ReadWriteStream[]) {
   } else {
     return new PassThrough({objectMode: true});
   }
+}
+
+/**
+ * A stream that takes file path strings, and outputs full Vinyl file objects
+ * for the file at each location.
+ */
+export class VinylReaderTransform extends Transform {
+
+  constructor() {
+    super({ objectMode: true });
+  }
+
+  _transform(
+    filePath: string,
+    encoding: string,
+    callback: (error?: Error, data?: File) => void
+  ): void {
+    fs.readFile(filePath, (err?: Error, data?: Buffer) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+      callback(null, new File({
+        path: filePath,
+        contents: data
+      }));
+    });
+  }
+
 }

--- a/test/analyzer_test.js
+++ b/test/analyzer_test.js
@@ -13,6 +13,7 @@
 const assert = require('chai').assert;
 const path = require('path');
 const StreamAnalyzer = require('../lib/analyzer').StreamAnalyzer;
+const mergeStream = require('merge-stream');
 const vfs = require('vinyl-fs-fake');
 
 suite('Analyzer', () => {
@@ -21,14 +22,18 @@ suite('Analyzer', () => {
 
     test('fragment to deps list has only uniques', (done) => {
       let root = path.resolve('test/analyzer-data');
-      let analyzer = new StreamAnalyzer(root, null, null, [
+      let fragments = [
         path.resolve(root, 'a.html'),
         path.resolve(root, 'b.html'),
-      ]);
-      vfs.src(path.join(root, '**'), {cwdbase: true})
+      ];
+      let analyzer = new StreamAnalyzer(root, null, null, fragments, fragments);
+      mergeStream(
+          vfs.src(path.join(root, '**'), {cwdbase: true}),
+          analyzer.dependencies
+        )
         .pipe(analyzer)
         .on('finish', () => {
-          analyzer.analyze.then((depsIndex) => {
+          analyzer.analyzeDependencies.then((depsIndex) => {
             let ftd = depsIndex.fragmentToDeps;
             for (let frag of ftd.keys()) {
               assert.deepEqual(ftd.get(frag), ['shared-1.html', 'shared-2.html']);
@@ -40,22 +45,104 @@ suite('Analyzer', () => {
 
     test("analyzing shell and entrypoint doesn't double load files", (done) => {
       let root = path.resolve('test/analyzer-data');
+      let sourceGlobs = [
+        path.resolve(root, 'a.html'),
+        path.resolve(root, 'b.html'),
+      ];
       let analyzer = new StreamAnalyzer(
           root,
           path.resolve(root, 'entrypoint.html'),
-          path.resolve(root, 'shell.html'));
-      vfs.src(root + '/**', {cwdbase: true})
+          path.resolve(root, 'shell.html'),
+          undefined,
+          sourceGlobs);
+      mergeStream(
+          vfs.src(path.join(root, '**'), {cwdbase: true}),
+          analyzer.dependencies
+        )
         .pipe(analyzer)
         .on('finish', () => {
-          analyzer.analyze.then((depsIndex) => {
+          analyzer.analyzeDependencies.then((depsIndex) => {
             assert.isTrue(depsIndex.depsToFragments.has('shared-2.html'));
             assert.isFalse(depsIndex.depsToFragments.has('/shell.html'));
             assert.isFalse(depsIndex.depsToFragments.has('/shared-2.html'));
             done();
-          }).catch((err) => done(err));
+          }).catch(done);
       });
     });
 
+  });
+
+  suite('.dependencies', () => {
+
+    test('outputs all dependencies needed by source', (done) => {
+      let root = path.resolve('test/analyzer-data');
+      let shell = path.resolve(root, 'shell.html');
+      let entrypoint = path.resolve(root, 'entrypoint.html');
+      let sourceGlobs = [
+        path.resolve(root, 'a.html'),
+        path.resolve(root, 'b.html'),
+      ];
+      let analyzer = new StreamAnalyzer(
+          root,
+          entrypoint,
+          shell,
+          undefined,
+          sourceGlobs.concat(shell, entrypoint));
+
+      let foundDependencies = new Set();
+      analyzer.dependencies.on('data', (file) => {
+        foundDependencies.add(file.path);
+      });
+
+      mergeStream(
+          vfs.src(sourceGlobs.concat(shell, entrypoint), {cwdbase: true}),
+          analyzer.dependencies
+        )
+        .pipe(analyzer)
+        .on('finish', () => {
+          // shared-1 is never imported by shell/entrypoint, so it is not included as a dep.
+          assert.isFalse(foundDependencies.has(path.resolve(root, 'shared-1.html')));
+          // shared-2 is imported by shell, so it is included as a dep.
+          assert.isTrue(foundDependencies.has(path.resolve(root, 'shared-2.html')));
+          done();
+        })
+        .on('error', done);
+    });
+
+    test('outputs all dependencies needed by source and given fragments', (done) => {
+      let root = path.resolve('test/analyzer-data');
+      let shell = path.resolve(root, 'shell.html');
+      let entrypoint = path.resolve(root, 'entrypoint.html');
+      let sourceGlobs = [
+        path.resolve(root, 'a.html'),
+        path.resolve(root, 'b.html'),
+      ];
+      let analyzer = new StreamAnalyzer(
+          root,
+          entrypoint,
+          shell,
+          sourceGlobs,
+          sourceGlobs.concat(shell, entrypoint));
+
+      let foundDependencies = new Set();
+      analyzer.dependencies.on('data', (file) => {
+        foundDependencies.add(file.path);
+      });
+
+      mergeStream(
+          vfs.src(sourceGlobs.concat(shell, entrypoint), {cwdbase: true}),
+          analyzer.dependencies
+        )
+        .pipe(analyzer)
+        .on('finish', () => {
+          // shared-1 is imported by 'a' & 'b', so it is included as a dep.
+          assert.isTrue(foundDependencies.has(path.resolve(root, 'shared-1.html')));
+          // shared-1 is imported by 'a' & 'b', so it is included as a dep.
+          assert.isTrue(foundDependencies.has(path.resolve(root, 'shared-2.html')));
+          done();
+        })
+        .on('error', done);
+    });
   });
 
 });

--- a/test/test-project/bower_components/unreachable-dep.html
+++ b/test/test-project/bower_components/unreachable-dep.html
@@ -1,0 +1,1 @@
+<div id="unreachable-dep"></div>

--- a/test/test-project/index.html
+++ b/test/test-project/index.html
@@ -1,1 +1,2 @@
 <link rel="import" href="shell.html">
+<link rel="import" href="source-dir/my-app.html">

--- a/test/test-project/source-dir/my-app.html
+++ b/test/test-project/source-dir/my-app.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/test/url-from-path_test.js
+++ b/test/url-from-path_test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const assert = require('chai').assert;
-const urlFromPath = require('../lib/url-from-path').default;
+const urlFromPath = require('../lib/path-transformers').urlFromPath;
 
 const WIN_ROOT_PATH = 'C:\\Users\\TEST_USER\\TEST_ROOT';
 const MAC_ROOT_PATH = '/Users/TEST_USER/TEST_ROOT';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "src/analyzer.ts",
     "src/bundle.ts",
     "src/fork-stream.ts",
+    "src/get-dependencies-from-document.ts",
     "src/optimize.ts",
     "src/polymer-build.ts",
     "src/polymer-project.ts",
@@ -39,7 +40,7 @@
     "src/streams.ts",
     "src/sw-precache.ts",
     "src/uglify-transform.ts",
-    "src/url-from-path.ts",
+    "src/path-transformers.ts",
     "typings/index.d.ts"
   ],
   "atom": {


### PR DESCRIPTION
~~*Note: Some JSDoc and a few more tests are still TODO, just wanted to get this out there today*~~

This PR adds a much smarter dependency stream based on dependency analysis of the application rather than simple glob matching. When run on some of our basic templates, build directories are something like 90+% smaller than they were before.

See `/test/test-project/gulpfile.js` for usage examples.

/cc @justinfagnani @robdodson
Resolves #3