### PR TITLE
no longer throws an error when no entrypoint or shell is given

### DIFF
--- a/src/polymer-project.ts
+++ b/src/polymer-project.ts
@@ -112,8 +112,12 @@ export class PolymerProject {
 
   constructor(options?: ProjectOptions) {
     this.root = options.root || process.cwd();
-    this.entrypoint = osPath.resolve(this.root, options.entrypoint);
-    this.shell = osPath.resolve(this.root, options.shell);
+    if (options.entrypoint) {
+      this.entrypoint = osPath.resolve(this.root, options.entrypoint);
+    }
+    if (options.shell) {
+      this.shell = osPath.resolve(this.root, options.shell);
+    }
     this.fragments = (options.fragments || [])
         .map((f) => osPath.resolve(this.root, f));
     this.sourceGlobs = (options.sourceGlobs || defaultSourceGlobs)

--- a/test/polymer-project_test.js
+++ b/test/polymer-project_test.js
@@ -36,6 +36,12 @@ suite('PolymerProject', () => {
     });
   })
 
+  test('will not throw an exception when created with minimum options', () => {
+    new PolymerProject({
+      root: path.resolve(__dirname, 'test-project'),
+    });
+  });
+
   test('reads sources', (done) => {
     let files = [];
     defaultProject.sources()


### PR DESCRIPTION
/cc @justinfagnani 