### PR TITLE
Handle external dependencies in hydrolosis resolver as well

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -20,7 +20,7 @@ import {Node, queryAll, predicates, getAttribute} from 'dom5';
 
 import {FileCB, VinylReaderTransform} from './streams';
 import {urlFromPath, pathFromUrl} from './path-transformers';
-import {DocumentDeps, getDependenciesFromDocument}
+import {DocumentDeps, getDependenciesFromDocument, isDependencyExternal}
   from './get-dependencies-from-document';
 
 const minimatchAll = require('minimatch-all');
@@ -266,8 +266,11 @@ class StreamResolver implements Resolver {
     logger.debug(`accept: ${url}`);
     let urlObject = parseUrl(url);
 
-    if (urlObject.hostname || !urlObject.pathname) {
-      return false;
+    // Resolve external files as empty strings. We filter these out later
+    // in the analysis process to make sure they aren't included in the build.
+    if (isDependencyExternal(url)) {
+      deferred.resolve('');
+      return true;
     }
 
     let urlPath = decodeURIComponent(urlObject.pathname);

--- a/src/get-dependencies-from-document.ts
+++ b/src/get-dependencies-from-document.ts
@@ -27,7 +27,7 @@ export interface DocumentDeps {
  * starts with '//', which can be an alias to the page's current protocol
  * in the browser.
  */
-function isDependencyExternal(url: string) {
+export function isDependencyExternal(url: string) {
   // TODO(fks) 08-01-2016: Add additional check for files on current hostname
   // but external to this application root. Ignore them.
   return urlParse(url).protocol !== null || url.startsWith('//');

--- a/test/polymer-project_test.js
+++ b/test/polymer-project_test.js
@@ -68,6 +68,7 @@ suite('PolymerProject', () => {
         let names = files.map((f) => unroot(f.path));
         let expected = [
           'bower_components/dep.html',
+          'bower_components/loads-external-dependencies.html',
         ];
         assert.sameMembers(names, expected);
         done();
@@ -99,6 +100,7 @@ suite('PolymerProject', () => {
         let expected = [
           'bower_components/dep.html',
           'bower_components/unreachable-dep.html',
+          'bower_components/loads-external-dependencies.html',
         ];
         assert.sameMembers(names, expected);
         done();
@@ -109,6 +111,7 @@ suite('PolymerProject', () => {
         dependencyStream
       ).pipe(projectWithIncludedDeps.analyzer);
     });
+
   });
 
   test('splits and rejoins scripts', (done) => {

--- a/test/test-project/bower_components/dep.html
+++ b/test/test-project/bower_components/dep.html
@@ -1,1 +1,4 @@
+<link rel="import" href="loads-external-dependencies.html">
+
 <div id="dep"></div>
+

--- a/test/test-project/bower_components/loads-external-dependencies.html
+++ b/test/test-project/bower_components/loads-external-dependencies.html
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="//example.com/style.min.css">
+<script src="https://www.example.com/script.js"></script>
+


### PR DESCRIPTION
Fixes https://github.com/Polymer/polymer-cli/issues/261 for real this time.

@garlicnation originally suggested a `NoopResolver` with string/regex matching, but I ultimately kept the logic in `StreamResolver` so that we could have more control over detecting what's external and whats not. 

/cc @justinfagnani 