### PR TITLE
use absolute file paths in stream resolver to prevent duplicates

### DIFF
--- a/test/polymer-project_test.js
+++ b/test/polymer-project_test.js
@@ -32,6 +32,8 @@ suite('PolymerProject', () => {
       shell: 'shell.html',
       sourceGlobs: [
         'source-dir/**',
+        'index.html',
+        'shell.html',
       ],
     });
   })
@@ -77,6 +79,25 @@ suite('PolymerProject', () => {
         defaultProject.sources(),
         dependencyStream
       ).pipe(defaultProject.analyzer);
+    });
+
+    test('reads dependencies in a monolithic (non-shell) application without timing out', (done) => {
+      let project = new PolymerProject({
+        root: path.resolve(__dirname, 'test-project'),
+        entrypoint: 'index.html',
+        sourceGlobs: [
+          'source-dir/**',
+          'index.html',
+          'shell.html',
+        ],
+      });
+
+      mergeStream(
+          project.sources(),
+          project.dependencies()
+        )
+        .pipe(project.analyzer)
+        .on('finish', done);
     });
 
     test('reads dependencies and includes additionally provided files', (done) => {

--- a/test/test-project/index.html
+++ b/test/test-project/index.html
@@ -1,2 +1,2 @@
-<link rel="import" href="shell.html">
-<link rel="import" href="source-dir/my-app.html">
+<link rel="import" href="/shell.html">
+<link rel="import" href="/source-dir/my-app.html">


### PR DESCRIPTION
First step in solving some of our index.html absolute path woes. By internally tracking absolute file paths instead of url paths we get rid of a lot of potential ambiguity.

Also adds tests for a monolithic architecture app (no wonder our support has been so lacking :)

Fixes https://github.com/Polymer/polymer-cli/issues/337
/cc @justinfagnani 