### PR TITLE
support relative root option

### DIFF
--- a/src/polymer-project.ts
+++ b/src/polymer-project.ts
@@ -32,7 +32,9 @@ const extensionsForType: {[mimetype: string]: string} = {
 
 export interface ProjectOptions {
   /**
-   * Path to the root of the project on the filesystem.
+   * Path to the root of the project on the filesystem. This can be an absolute
+   * path, or a path relative to the current working directory. Defaults to the
+   * current working directory of the process.
    */
   root?: string;
 
@@ -112,7 +114,11 @@ export class PolymerProject {
   bundler: Bundler;
 
   constructor(options?: ProjectOptions) {
-    this.root = options.root || process.cwd();
+    this.root = process.cwd();
+
+    if (options.root) {
+      this.root = osPath.resolve(this.root, options.root);
+    }
     if (options.entrypoint) {
       this.entrypoint = osPath.resolve(this.root, options.entrypoint);
     }

--- a/test/polymer-project_test.js
+++ b/test/polymer-project_test.js
@@ -17,17 +17,17 @@ const File = require('vinyl');
 const mergeStream = require('merge-stream');
 
 const PolymerProject = require('../lib/polymer-project').PolymerProject;
+const testProjectRoot = path.resolve(__dirname, 'test-project');
 
 suite('PolymerProject', () => {
 
   let defaultProject;
-  let root = path.resolve(__dirname, 'test-project');
 
-  let unroot = (p) => p.substring(root.length + 1);
+  let unroot = (p) => p.substring(testProjectRoot.length + 1);
 
   setup(() => {
     defaultProject = new PolymerProject({
-      root: path.resolve(__dirname, 'test-project'),
+      root: 'test/test-project/',
       entrypoint: 'index.html',
       shell: 'shell.html',
       sourceGlobs: [
@@ -40,8 +40,22 @@ suite('PolymerProject', () => {
 
   test('will not throw an exception when created with minimum options', () => {
     new PolymerProject({
-      root: path.resolve(__dirname, 'test-project'),
+      root: 'test/test-project/',
     });
+  });
+
+  test('will properly convert relative root path into full path', () => {
+    let projectWithRelativeRoot = new PolymerProject({
+      root: 'test/test-project/',
+    });
+    assert.equal(projectWithRelativeRoot.root, testProjectRoot);
+  });
+
+  test('will properly set full root path', () => {
+    let projectWithFullRootPath = new PolymerProject({
+      root: testProjectRoot,
+    });
+    assert.equal(projectWithFullRootPath.root, testProjectRoot);
   });
 
   test('reads sources', (done) => {
@@ -83,7 +97,7 @@ suite('PolymerProject', () => {
 
     test('reads dependencies in a monolithic (non-shell) application without timing out', (done) => {
       let project = new PolymerProject({
-        root: path.resolve(__dirname, 'test-project'),
+        root: testProjectRoot,
         entrypoint: 'index.html',
         sourceGlobs: [
           'source-dir/**',
@@ -103,7 +117,7 @@ suite('PolymerProject', () => {
     test('reads dependencies and includes additionally provided files', (done) => {
       let files = [];
       let projectWithIncludedDeps = new PolymerProject({
-        root: path.resolve(__dirname, 'test-project'),
+        root: testProjectRoot,
         entrypoint: 'index.html',
         shell: 'shell.html',
         sourceGlobs: [


### PR DESCRIPTION
Previously, `root` only supported full system file paths. This made the option useless in a shared project. Now we support paths relative to the current working directory where the gulpfile is run.

/cc @robdodson @justinfagnani 