### PR TITLE
remove redundant pushDependency() call after analysis

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -273,11 +273,7 @@ export class StreamAnalyzer extends Transform {
     // the dependency stream.
     this._dependencyAnalysis.fragmentToFullDeps.set(filePath, deps);
     this._dependencyAnalysis.fragmentToDeps.set(filePath, deps.imports);
-    deps.scripts.forEach((url) => this.pushDependency(url));
-    deps.styles.forEach((url) => this.pushDependency(url));
     deps.imports.forEach((url) => {
-      this.pushDependency(url);
-
       const entrypointList: string[] = this._dependencyAnalysis.depsToFragments.get(url);
       if (entrypointList) {
         entrypointList.push(filePath);


### PR DESCRIPTION
Found this as a part of new analyzer architecture, this change will simplify the architecture and remove a ton of debug noise.

Dependencies are loaded during analysis to create the entire dependency tree. They are loaded by calling `pushDependency()` inside the Analyzer.loader. But after this, we've been calling `pushDependency()` again on each dependency. This may have been necessary in the old analyzer, but it is no longer necessary in the new one.

/cc @justinfagnani @rictic @usergenic 