### PR TITLE
Updated to polymer-bundler 2.0.0-pre.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 <!-- List New Changes Here -->
-* None currently.
+* Update the version of `polymer-bundler` to fix several bugs:
+  - Fix regressions in url attribute updating (src, href, assetpath).
+  - Added support for `<base>` href and target attribute emulation on bundled output.
+  - Whitespace-agnostic License comment deduplication
+  - Server-Side Includes no longer stripped.
 
 ## [0.8.0] - 2017-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Update the version of `polymer-bundler` to fix several bugs:
   - Fix regressions in url attribute updating (src, href, assetpath).
   - Added support for `<base>` href and target attribute emulation on bundled output.
-  - Whitespace-agnostic License comment deduplication
-  - Server-Side Includes no longer stripped.
+  - Whitespace-agnostic license comment deduplication.
+  - Server-side includes no longer stripped as comments.
 
 ## [0.8.0] - 2017-02-14
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "parse5": "^2.2.2",
     "plylog": "^0.4.0",
     "polymer-analyzer": "2.0.0-alpha.24",
-    "polymer-bundler": "2.0.0-pre.5",
+    "polymer-bundler": "2.0.0-pre.6",
     "polymer-project-config": "^2.0.0",
     "sw-precache": "^4.2.0",
     "vinyl": "^1.1.1",


### PR DESCRIPTION
Fixes many issues:
- Handle `<base href="...">` values correctly when inlining imports.
- Apply `<base target="...">` to links and forms in the same document as
  appropriate.
- License comments are deduplicated properly now.
- Server-Side Include comments `<!--# ... -->` are no longer stripped.
- Fixed a bug where element attributes inside `<template>` tags were not
  being rewritten when html imports were inlined.
- [x] CHANGELOG.md has been updated
