### PR TITLE
`PolymerProject#bundler` -> `PolymerProject#bundler()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 <!-- List New Changes Here -->
+
+* PolymerProject's `bundler` property is now a `bundler()` method, returning a new BuildBundler stream on each call.  This is to support parallel pipelines using bundler.
 
 ## [0.8.4] - 2017-03-04
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const sourcesStream = project.sources()
   .pipe(sourcesHtmlSplitter.split()) // split inline JS & CSS out into individual .js & .css files
   .pipe(gulpif(/\.js$/, uglify()))
   .pipe(gulpif(/\.css$/, cssSlam()))
-  .pipe(gulpif(/\.html$/, htmlMinifier())) 
+  .pipe(gulpif(/\.html$/, htmlMinifier()))
   .pipe(sourcesHtmlSplitter.rejoin()); // rejoins those files back into their original location
 
 // NOTE: If you want to split/rejoin your dependencies stream as well, you'll need to create a new HtmlSplitter for that stream.
@@ -115,7 +115,7 @@ const mergeStream = require('merge-stream');
 
 // Create a build pipeline to bundle our application before writing to the 'build/' dir
 mergeStream(project.sources(), project.dependencies())
-  .pipe(project.bundler)
+  .pipe(project.bundler())
   .pipe(gulp.dest('build/'));
 ```
 
@@ -199,4 +199,3 @@ You can compile polymer-build from source by cloning the repo and then running `
 ## Supported Node.js Versions
 
 polymer-build officially supports the latest LTS (4.x) and stable (6.x) versions of Node.js.
-

--- a/src/polymer-project.ts
+++ b/src/polymer-project.ts
@@ -32,16 +32,6 @@ export class PolymerProject {
    */
   analyzer: BuildAnalyzer;
 
-  /**
-   * A `Transform` stream that modifies the files that pass through it based
-   * on the dependency analysis done by the `analyzer` transform. It "bundles"
-   * a project by injecting its dependencies into the application fragments
-   * themselves, so that a minimum number of requests need to be made to load.
-   *
-   * (NOTE: The analyzer stream must be in the pipeline somewhere before this.)
-   */
-  bundler: BuildBundler;
-
   constructor(config: ProjectConfig|ProjectOptions|string) {
     if (config.constructor.name === 'ProjectConfig') {
       this.config = <ProjectConfig>config;
@@ -54,7 +44,19 @@ export class PolymerProject {
     logger.debug(`build config loaded:`, this.config);
 
     this.analyzer = new BuildAnalyzer(this.config);
-    this.bundler = new BuildBundler(this.config, this.analyzer);
+  }
+
+  /**
+   * Returns a `Transform` stream that modifies the files that pass through it
+   * based on the dependency analysis done by the `analyzer` transform. It
+   * "bundles" a project by injecting its dependencies into the application
+   * fragments themselves, so that a minimum number of requests need to be made
+   * to load.
+   *
+   * (NOTE: The analyzer stream must be in the pipeline somewhere before this.)
+   */
+  bundler(): BuildBundler {
+    return new BuildBundler(this.config, this.analyzer);
   }
 
   /**

--- a/src/test/polymer-project_test.ts
+++ b/src/test/polymer-project_test.ts
@@ -78,6 +78,12 @@ suite('PolymerProject', () => {
     assert.isTrue(getFlowingState(dependencyStream));
   });
 
+  test('the bundler method returns a different bundler each time', () => {
+    const bundlerA = defaultProject.bundler();
+    const bundlerB = defaultProject.bundler();
+    assert.notEqual(bundlerA, bundlerB);
+  });
+
   suite('.dependencies()', () => {
 
     test('reads dependencies', (done) => {

--- a/test-fixtures/test-project/gulpfile.js
+++ b/test-fixtures/test-project/gulpfile.js
@@ -64,7 +64,7 @@ gulp.task('test1', ['clean'], (cb) => {
   // this fork will generate the bundle files for the project
   let bundledPhase =
       fork(allFiles)
-          .pipe(project.bundler)
+          .pipe(project.bundler())
           // write to the bundled folder
           // TODO(justinfagnani): allow filtering of files before writing
           .pipe(gulp.dest('build/bundled'));


### PR DESCRIPTION
 - Changed the `PolymerProject` property `bundler` to a method `bundler()` that returns a new `BuildBundler` instance.
 - [x] CHANGELOG.md has been updated
