### PR TITLE
Change format script in package.json to not reference non-existant test/ directory (keeps printing warn message)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "test": "gulp test",
     "prepublish": "gulp lint && gulp test",
-    "format": "find src/ test/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"
+    "format": "find src/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`"format": "find src/ test/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"` is now `"format": "find src/ -iname '*.ts' -o -iname '*.js' | xargs clang-format --style=file -i"`