### PR TITLE
Fix issues with inlined files output by BuildBundler stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-<!-- List New Changes Here -->
 
 * [BREAKING] Dropped support for node v4, added support for node v8. See our [node version support policy](https://www.polymer-project.org/2.0/docs/tools/node-support) for details.
 * Dependency updates.  Upgraded to new `polymer-bundler`, `polymer-analyzer` and `dom5` versions.
 * Fixed bug where `<html>`, `<head>` and `<body>` were added to documents mutated by `HtmlSplitter` and the `CustomElementsES5AdapterInjector`.
 * Print build-time warnings and errors with full location information, and precise underlines of the place where the problem was identified.
+* Fixed issue where two copies of entrypoint files with same name are emitted by bundler stream: an un-bundled one, followed by bundled one.
+* Fixed issue where html imports were emitted by bundler as individual files even though they were bundled.
 
 ## [1.1.0] - 2017-04-14
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -30,6 +30,10 @@ export class BuildBundler extends Transform {
   private _buildAnalyzer: BuildAnalyzer;
   private _bundler: Bundler;
 
+  // A map of urls to file objects.  As the transform stream handleds files
+  // coming into the stream, it collects all files here.  After bundlling,
+  // we remove files from this set that have been inlined and replace
+  // entrypoint/fragment files with bundled versions.
   files = new Map<string, File>();
 
   constructor(config: ProjectConfig, buildAnalyzer: BuildAnalyzer) {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -77,9 +77,7 @@ export class BuildBundler extends Transform {
       });
       this._mapFile(file);
     }
-    for (const file of this.files.values()) {
-      this.push(file);
-    }
+    this.files.forEach((file) => this.push(file));
     // end the stream
     done();
   }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -77,8 +77,8 @@ export class BuildBundler extends Transform {
       });
       this._mapFile(file);
     }
-    for (const filepath of this.files.keys()) {
-      this.push(this.files.get(filepath));
+    for (const file of this.files.values()) {
+      this.push(file);
     }
     // end the stream
     done();

--- a/src/test/bundle_test.ts
+++ b/src/test/bundle_test.ts
@@ -346,7 +346,6 @@ suite('BuildBundler', () => {
     assert.include(bundledHtml, '.simply-red', 'simple-style.css');
   });
 
-
   test('bundler deals with posix platform separators on win32', async() => {
     const posixSepPaths = new FileTransform((stream, file) => {
       if (path.sep === '\\') {
@@ -379,5 +378,17 @@ suite('BuildBundler', () => {
     assert.include(
         bundledHtml, '<dom-module id="my-element-2">', 'simple-import-2.html');
     assert.include(bundledHtml, '.simply-red', 'simple-style.css');
+  });
+
+  test('bundler does not output imports which have been bundled', async() => {
+    await setupTest({
+      entrypoint: 'entrypoint-only.html',
+      sources: ['framework.html', 'entrypoint-only.html'],
+    });
+    // We should have an entrypoint-only.html file (bundled).
+    assert.isOk(getFile('entrypoint-only.html'));
+
+    // We should not have the inlined file in the output.
+    assert.isNotOk(getFile('framework.html'));
   });
 });


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Fixed https://github.com/Polymer/polymer-build/issues/167 where two copies of entrypoint files with same name are emitted by bundler stream: an un-bundled one, followed by bundled one.  
 - Fixed https://github.com/Polymer/polymer-build/issues/142 where html imports were emitted by bundler as individual files even though they were bundled.
 - This depends on a new release of polymer-bundler following review/merge of https://github.com/Polymer/polymer-bundler/pull/464