### PR TITLE
Upgrade bundler to 2.0.0 pre.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+* Dependency updates.  Upgraded to new `polymer-bundler`.  Most important update is a fix to bug whereby `lazy-import` links were being moved out of their `<dom-module>` containers.
+
 ## [1.2.0] - 2017-05-02
 
 * Dependency updates.  Upgraded to new `polymer-bundler`, `polymer-analyzer` and `dom5` versions.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "parse5": "^2.2.2",
     "plylog": "^0.5.0",
     "polymer-analyzer": "2.0.0-alpha.40",
-    "polymer-bundler": "2.0.0-pre.13",
+    "polymer-bundler": "2.0.0-pre.14",
     "polymer-project-config": "^2.0.0",
     "sw-precache": "^4.2.0",
     "vinyl": "^1.1.1",


### PR DESCRIPTION
 - Dependency update for polymer-bundler.
 - Made some methods on BuildBundler explicitly private that were written as private.
 - Removed private `_strategy` and `_urlMapper` properties on BuildBundler that were redundant now that Bundler API changed and no longer required them to be squirreled away for subsequent call to generateManifest.
 - [x] CHANGELOG.md has been updated
