### PR TITLE
Minor fixup to the sample code for bundler in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,18 @@ mergeStream(project.sources(), project.dependencies())
 The bundler() method accepts an options object to configure bundling.  See [Using polymer-bundler programmatically](https://github.com/polymer/polymer-bundler#using-polymer-bundler-programmatically) for a detailed list of accepted options.
 
 ```js
+const {generateCountingSharedBundleUrlMapper,
+       generateSharedDepsMergeStrategy} = require('polymer-bundler');
+
+mergeStream(project.sources(), project.dependencies())
   .pipe(project.bundler({
     excludes: ['bower_components/polymer-code-mirror'],
     sourcemaps: true,
     stripComments: true,
-    strategy: require('polymer-bundler/lib/bundle-manifest')
-      .generateSharedDepsMergeStrategy(3)
+    strategy: generateSharedDepsMergeStrategy(3),
+    urlMapper: generateCountingSharedBundleUrlMapper('shared/bundle_')
   }))
+  .pipe(gulp.dest('build/'));
 ```
 
 ### Generating a Service Worker


### PR DESCRIPTION
```js
const {generateCountingSharedBundleUrlMapper,
       generateSharedDepsMergeStrategy} = require('polymer-bundler');

mergeStream(project.sources(), project.dependencies())
  .pipe(project.bundler({
    excludes: ['bower_components/polymer-code-mirror'],
    sourcemaps: true,
    stripComments: true,
    strategy: generateSharedDepsMergeStrategy(3),
    urlMapper: generateCountingSharedBundleUrlMapper('shared/bundle_')
  }))
  .pipe(gulp.dest('build/'));
```