### PR TITLE
bug(build): Use polymer root as cwd to fix build output directory

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -105,6 +105,7 @@ export class BuildAnalyzer {
   analyzer: Analyzer;
   started: boolean = false;
   sourceFilesLoaded: boolean = false;
+  cwd: string;
 
   private _sourcesStream: NodeJS.ReadableStream;
   private _sourcesProcessingStream: NodeJS.ReadWriteStream;
@@ -126,6 +127,8 @@ export class BuildAnalyzer {
 
   constructor(config: ProjectConfig) {
     this.config = config;
+
+    this.cwd = this.config.root || process.cwd();
 
     this.loader = new StreamLoader(this);
     this.analyzer = new Analyzer({
@@ -153,6 +156,7 @@ export class BuildAnalyzer {
     // Create the base streams for sources & dependencies to be read from.
     this._dependenciesStream = new PassThrough({objectMode: true});
     this._sourcesStream = vinylSrc(this.config.sources, {
+      cwd: this.cwd,
       cwdbase: true,
       nodir: true,
     });
@@ -184,7 +188,7 @@ export class BuildAnalyzer {
             .on('error',
                 (err: Error) =>
                     this._dependenciesProcessingStream.emit('error', err))
-            .pipe(new VinylReaderTransform())
+            .pipe(new VinylReaderTransform(this.cwd))
             .on('error',
                 (err: Error) =>
                     this._dependenciesProcessingStream.emit('error', err))

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -108,6 +108,7 @@ export class BuildBundler extends AsyncTransformStream<File, File> {
     // Map the bundles into the file map.
     for (const [filename, document] of documents) {
       this._mapFile(new File({
+        cwd: this.config.root,
         path: pathFromUrl(this.config.root, filename),
         contents: new Buffer(parse5.serialize(document.ast)),
       }));

--- a/src/polymer-project.ts
+++ b/src/polymer-project.ts
@@ -85,6 +85,7 @@ export class PolymerProject {
     // combine.
     if (this.config.extraDependencies.length > 0) {
       const includeStream = vinylSrc(this.config.extraDependencies, {
+        cwd: this.config.root,
         cwdbase: true,
         nodir: true,
         passthrough: true,

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -255,14 +255,16 @@ export abstract class AsyncTransformStream<In extends{}, Out extends{}> extends
  * for the file at each location.
  */
 export class VinylReaderTransform extends AsyncTransformStream<string, File> {
-  constructor() {
-    super({objectMode: true});
+  private _cwd: string;
+  constructor(cwd: string) {
+    super({ objectMode: true });
+    this._cwd =  cwd
   }
 
   protected async *
       _transformIter(paths: AsyncIterable<string>): AsyncIterable<File> {
     for await (const filePath of paths) {
-      yield new File({path: filePath, contents: await fs.readFile(filePath)});
+      yield new File({cwd: this._cwd, path: filePath, contents: await fs.readFile(filePath)});
     }
   }
 }


### PR DESCRIPTION
The stream containing the sources and dependencies now have the paths relative to the polymer.root instead of the process.CWD.

Breaking change.

The build output is now correctly written to the build folder.


As there are multiple ways into fixing this, please let me know if the solution i made is not according to your standards!

I will do some more testing, my application is now properly outputted in the correct build folder.
But i do see one error (webcomponentsjs) is still inside the wrong folder.
Will look into that one and test with more apps.

closes: https://github.com/Polymer/polymer-build/issues/234

 - [ ] CHANGELOG.md has been updated
