### PR TITLE
Allow filtering analysis warnings

### DIFF
--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -23,7 +23,7 @@ import {Writable} from 'stream';
 
 import {getFlowingState} from './util';
 import {BuildAnalyzer} from '../analyzer';
-import {waitForAll} from '../streams';
+import {waitFor, waitForAll} from '../streams';
 
 /**
  * Streams will remain paused unless something is listening for it's data.
@@ -271,6 +271,28 @@ suite('Analyzer', () => {
                   assert.isTrue(printWarningsSpy.calledOnce);
                 });
       });
+
+  test('analyzer filters warnings', () => {
+    const root = path.resolve('test-fixtures/project-analysis-warning');
+    const sources = [path.join(root, '**')];
+
+    const config = new ProjectConfig({
+      root,
+      sources,
+      lint: {
+        rules: ['polymer-2'],
+        ignoreWarnings: ['invalid-polymer-expression']
+      }
+    });
+
+    const analyzer = new BuildAnalyzer(config);
+    analyzer.sources().pipe(new NoopStream());
+
+    return waitFor(analyzer.sources()).then(() => {
+      assert.isTrue(analyzer.warnings.size === 0);
+    });
+
+  });
 
   test('calling sources() starts analysis', async () => {
     const config = new ProjectConfig({

--- a/test-fixtures/project-analysis-warning/index.html
+++ b/test-fixtures/project-analysis-warning/index.html
@@ -1,0 +1,10 @@
+<dom-module id="my-element">
+  <template>
+    <span>[[invalid-property]]</span>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'my-element'
+  });
+</script>


### PR DESCRIPTION
This is a quick fix for #152 which reuses linting options for `polymer-cli` to allow filtering warnings emitted during the analysis.