### PR TITLE
fix silent (!) build failure when several source filepaths cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
+* Fixed issue where the build silently fails when several source dependencies are missing
 
 ## [2.1.1] - 2017-10-23
 * Updated `polymer-bundler` to 3.1.1, to fix an issue with deprecated CSS imports being inlined into the wrong templates.

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -249,7 +249,6 @@ export class BuildAnalyzer {
       if (this.config.isSource(filePath)) {
         const err = new Error(`Not found: ${filePath}`);
         this.loader.rejectDeferredFile(filePath, err);
-        return;
       }
     }
 

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -182,7 +182,7 @@ suite('Analyzer', () => {
 
         let errorCounter = 0;
         const errorListener = (err: Error) => {
-          assert.equal(err.message, '2 error(s) occurred during build.');
+          assert.equal(err.message, '3 error(s) occurred during build.');
           errorCounter++;
           if (errorCounter >= 2) {
             done();

--- a/src/test/analyzer_test.ts
+++ b/src/test/analyzer_test.ts
@@ -182,7 +182,7 @@ suite('Analyzer', () => {
 
         let errorCounter = 0;
         const errorListener = (err: Error) => {
-          assert.equal(err.message, '1 error(s) occurred during build.');
+          assert.equal(err.message, '2 error(s) occurred during build.');
           errorCounter++;
           if (errorCounter >= 2) {
             done();

--- a/test-fixtures/bad-src-import/src/a.html
+++ b/test-fixtures/bad-src-import/src/a.html
@@ -1,3 +1,4 @@
 <link rel="import" href="../dependencies/dep-1.html">
 <link rel="import" href="broken-path/to-missing-file-in-src-directory.html">
 <link rel="import" href="broken-path/to-another-missing-file-in-src-directory.html">
+<link rel="lazy-import" href="broken-path/to-lazy-missing-file-in-src-directory.html">

--- a/test-fixtures/bad-src-import/src/a.html
+++ b/test-fixtures/bad-src-import/src/a.html
@@ -1,2 +1,3 @@
 <link rel="import" href="../dependencies/dep-1.html">
 <link rel="import" href="broken-path/to-missing-file-in-src-directory.html">
+<link rel="import" href="broken-path/to-another-missing-file-in-src-directory.html">


### PR DESCRIPTION
This PR ensures that the [`scan()`](https://github.com/Polymer/polymer-analyzer/blob/master/src/core/analysis-context.ts#L337) method _gets completed_ for every source file in the project. Currently, the scan method _gets started_ but would never _get completed_ if there is more than one missing source file dependency in dependencies tree.

A `scan()` of source file gets completed when all dependencies of that file are known (resolved or rejected). That's why when the project's sources stream is completed it's important to ensure _all_ deferred source get rejected--not only the first one.

If some of the deferred dependencies remain pending, the analysis of the toplevel source file never continues after [`await this._cache.dependencyGraph.whenReady(resolvedUrl);`](https://github.com/Polymer/polymer-analyzer/blob/master/src/core/analysis-context.ts#L355). 

This PR fixes https://github.com/Polymer/polymer-cli/issues/936, https://github.com/Polymer/polymer-cli/issues/904 and https://github.com/Polymer/polymer-build/issues/251.

It might be also related to https://github.com/Polymer/polymer-build/issues/272.

 - [x] CHANGELOG.md has been updated