### PR TITLE
Integrate module to AMD babel plugin to jsTransform.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Add new, unreleased changes here. -->
 * Fix dependency specification for `babel-core`
 * Add `jsTransform` function, factored out of `optimize-streams` module (so that it can be shared with Polyserve).
+* Renamed `jsTransform` option from `compile` to `compileToEs5` to clarify its behavior.
+* Added `transformEsModulesToAmd` option to `jsTransform` and JS stream transformer.
 
 ## [2.3.3] - 2018-03-14
 * Don't run Babel at all if there are no meaningful changes to make.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-syntax-export-extensions": "^6.13.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+    "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-minify": "^0.3.0",

--- a/src/optimize-streams.ts
+++ b/src/optimize-streams.ts
@@ -46,6 +46,7 @@ export interface OptimizeOptions {
     minify?: boolean|{exclude?: string[]},
     compile?: boolean|{exclude?: string[]},
     moduleResolution?: ModuleResolutionStrategy,
+    transformEsModulesToAmd?: boolean,
   };
 }
 
@@ -105,10 +106,11 @@ export class JsTransform extends GenericOptimizeTransform {
         options.minify ? notExcluded(options.minify) : () => false;
 
     const transformer = (content: string, file: File) => jsTransform(content, {
-      compile: shouldCompileFile(file),
+      compileToEs5: shouldCompileFile(file),
       minify: shouldMinifyFile(file),
       moduleResolution: options.moduleResolution,
       filePath: file.path,
+      transformEsModulesToAmd: options.transformEsModulesToAmd,
     });
 
     super('babel-compile', transformer);

--- a/src/test/js-transform_test.ts
+++ b/src/test/js-transform_test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+import stripIndent = require('strip-indent');
+
+import {jsTransform} from '../js-transform';
+
+suite('jsTransform', () => {
+  test('compiles to ES5', () => {
+    assert.equal(
+        jsTransform('const foo = 3;', {compileToEs5: true}), 'var foo = 3;');
+  });
+
+  test('minifies', () => {
+    assert.equal(jsTransform('const foo = 3;', {minify: true}), 'const foo=3;');
+  });
+
+  test('compiles and minifies', () => {
+    assert.equal(
+        jsTransform('const foo = 3;', {compileToEs5: true, minify: true}),
+        'var foo=3;');
+  });
+
+  test('does not unnecessarily reformat', () => {
+    // Even with no transform plugins, parsing and serializing with Babel will
+    // make some minor formatting changes to the code, such as removing trailing
+    // newlines. Check that we don't do this when no transformations were
+    // configured.
+    assert.equal(jsTransform('const foo = 3;\n', {}), 'const foo = 3;\n');
+  });
+
+  test('rewrites bare module specifiers to paths', () => {
+    const fixtureRoot =
+        path.join(__dirname, '..', '..', 'test-fixtures', 'npm-modules');
+    const filePath = path.join(fixtureRoot, 'foo.js');
+
+    const input = stripIndent(`
+      import { dep1 } from 'dep1';
+      import { dep2 } from 'dep2';
+      import { dep2A } from 'dep2/a';
+      import { dep3 } from 'dep3';
+      import { dep4 } from 'dep4';
+
+      import { p1 } from '/already/a/path.js';
+      import { p2 } from './already/a/path.js';
+      import { p3 } from '../already/a/path.js';
+      import { p4 } from '../already/a/path.js';
+      import { p5 } from 'http://example.com/already/a/path.js';
+    `);
+
+    const expected = stripIndent(`
+      import { dep1 } from './node_modules/dep1/index.js';
+      import { dep2 } from './node_modules/dep2/dep2.js';
+      import { dep2A } from './node_modules/dep2/a.js';
+      import { dep3 } from './node_modules/dep3/dep3-module.js';
+      import { dep4 } from './node_modules/dep4/dep4-module.js';
+
+      import { p1 } from '/already/a/path.js';
+      import { p2 } from './already/a/path.js';
+      import { p3 } from '../already/a/path.js';
+      import { p4 } from '../already/a/path.js';
+      import { p5 } from 'http://example.com/already/a/path.js';
+    `);
+
+    const result = jsTransform(input, {moduleResolution: 'node', filePath});
+    assert.equal(result.trim(), expected.trim());
+  });
+
+  test('transforms ES modules to AMD', () => {
+    const input = stripIndent(`
+      import { dep1 } from 'dep1';
+      export const foo = 'foo';
+    `);
+
+    const expected = stripIndent(`
+      define(['exports', 'dep1'], function (exports, _dep) {
+          'use strict';
+
+          Object.defineProperty(exports, "__esModule", {
+              value: true
+          });
+          exports.foo = undefined;
+          const foo = exports.foo = 'foo';
+      });
+    `);
+
+    const result = jsTransform(input, {transformEsModulesToAmd: true});
+    assert.equal(result.trim(), expected.trim());
+  });
+});

--- a/src/test/optimize-streams_test.ts
+++ b/src/test/optimize-streams_test.ts
@@ -91,27 +91,11 @@ suite('optimize-streams', () => {
       import { dep1 } from 'dep1';
       import { dep2 } from 'dep2';
       import { dep2A } from 'dep2/a';
-      import { dep3 } from 'dep3';
-      import { dep4 } from 'dep4';
-
-      import { p1 } from '/already/a/path.js';
-      import { p2 } from './already/a/path.js';
-      import { p3 } from '../already/a/path.js';
-      import { p4 } from '../already/a/path.js';
-      import { p5 } from 'http://example.com/already/a/path.js';
       `);
       const expected = stripIndent(`
       import { dep1 } from './node_modules/dep1/index.js';
       import { dep2 } from './node_modules/dep2/dep2.js';
       import { dep2A } from './node_modules/dep2/a.js';
-      import { dep3 } from './node_modules/dep3/dep3-module.js';
-      import { dep4 } from './node_modules/dep4/dep4-module.js';
-
-      import { p1 } from '/already/a/path.js';
-      import { p2 } from './already/a/path.js';
-      import { p3 } from '../already/a/path.js';
-      import { p4 } from '../already/a/path.js';
-      import { p5 } from 'http://example.com/already/a/path.js';
       `);
 
       const result = await getOnlyFile(pipeStreams([


### PR DESCRIPTION
Also:
- Add unit tests to `jsTransform`.
- Expose `isComponentRequest` option for Polyserve to use.
- Renamed `compile` to `compileToEs5` to clarify what it does.

Part of #269.

(Note this does not yet include the dependency chaining from https://github.com/Polymer/polyserve/commit/fc33cd50bfa87bf187be797ff7c336dece05c95c which I intend to add in a follow up).

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
