### PR TITLE
A few changes for Polyserve integration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* AMD loader will now only be injected into an HTML document if it contains at least one `type=module` script.
+* Added `softSyntaxError` option to `jsTransform`. If set, Babel parse errors will no longer throw. Instead, a console error will be logged, and the original JS returned.
+* Expose `htmlTransform` from main package index.
+
 <!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.4] - 2018-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased changes here. -->
+
+## [3.0.0-pre.5] - 2018-03-28
 * AMD loader will now only be injected into an HTML document if it contains at least one `type=module` script.
 * Added `softSyntaxError` option to `jsTransform`. If set, Babel parse errors will no longer throw. Instead, a console error will be logged, and the original JS returned.
 * Expose `htmlTransform` from main package index.
-
-<!-- Add new, unreleased changes here. -->
 
 ## [3.0.0-pre.4] - 2018-03-28
 * ES to AMD module transformation is now supported by `getOptimizeStreams` and `htmlTransform`. Additionally:

--- a/src/html-transform.ts
+++ b/src/html-transform.ts
@@ -133,7 +133,8 @@ export function htmlTransform(
         finalModuleScript.parentNode!, finalModuleScript, fragment);
   }
 
-  if (options.injectAmdLoader) {
+  if (options.injectAmdLoader && shouldTransformEsModuleToAmd &&
+      firstModuleScript !== undefined) {
     const fragment = parse5.parseFragment('<script></script>\n');
     dom5.setTextContent(fragment.childNodes![0], getMinifiedRequireJs());
     const requireJsScript = fragment.childNodes![0];
@@ -142,15 +143,8 @@ export function htmlTransform(
     // there is one) because there may be some UMD dependencies that we want to
     // continue to load in global mode instead of AMD mode (which is detected by
     // the presence of the `require` global).
-    if (firstModuleScript !== undefined) {
-      dom5.insertBefore(
-          firstModuleScript.parentNode!, firstModuleScript, fragment);
-    } else {
-      // TODO(aomarks) If there were no modules, where do we put the AMD loader?
-      const headOrDocument =
-          dom5.query(document, dom5.predicates.hasTagName('head')) || document;
-      dom5.append(headOrDocument, fragment);
-    }
+    dom5.insertBefore(
+        firstModuleScript.parentNode!, firstModuleScript, fragment);
 
     if (wctScript !== undefined) {
       addWctTimingHack(wctScript, requireJsScript);

--- a/src/polymer-build.ts
+++ b/src/polymer-build.ts
@@ -5,6 +5,7 @@ export {BuildBundler} from './bundle';
 export {addCustomElementsEs5Adapter} from './custom-elements-es5-adapter';
 export {forkStream} from './fork-stream';
 export {HtmlSplitter} from './html-splitter';
+export {htmlTransform} from './html-transform';
 export {jsTransform} from './js-transform';
 export {getOptimizeStreams, OptimizeOptions} from './optimize-streams';
 export {PolymerProject} from './polymer-project';

--- a/src/test/html-transform_test.ts
+++ b/src/test/html-transform_test.ts
@@ -137,7 +137,7 @@ suite('htmlTransform', () => {
     test('external script', () => {
       const input = `
         <html><head></head><body>
-          <script type="module" src="depA.js"><script>
+          <script type="module" src="depA.js"></script>
         </body></html>`;
 
       const expected = `
@@ -274,7 +274,7 @@ suite('htmlTransform', () => {
         <html><head></head><body>
           <script>console.log('non-module');</script>
 
-          <script type="module" src="depA.js"><script>
+          <script type="module" src="depA.js"></script>
         </body></html>`;
 
       const expected = `
@@ -295,6 +295,22 @@ suite('htmlTransform', () => {
         },
       });
       assertEqualIgnoringWhitespace(replaceGiantScripts(result), expected);
+    });
+
+    test('does not add AMD loader when no modules', () => {
+      const input = `
+        <html><head></head><body>
+          <script>console.log('non-module');</script>
+          <script src="depA.js"></script>
+        </body></html>`;
+
+      const result = htmlTransform(input, {
+        injectAmdLoader: true,
+        js: {
+          transformEsModulesToAmd: true,
+        },
+      });
+      assertEqualIgnoringWhitespace(result, input);
     });
 
     test('adds hack for Web Component Tester', () => {

--- a/src/test/js-transform_test.ts
+++ b/src/test/js-transform_test.ts
@@ -43,6 +43,22 @@ suite('jsTransform', () => {
     assert.equal(jsTransform('const foo = 3;\n', {}), 'const foo = 3;\n');
   });
 
+  suite('parse errors', () => {
+    const invalidJs = ';var{';
+
+    test('throw when softSyntaxError is false', () => {
+      assert.throws(
+          () => jsTransform(
+              invalidJs, {compileToEs5: true, softSyntaxError: false}));
+    });
+
+    test('do not throw when softSyntaxError is true', () => {
+      assert.equal(
+          jsTransform(invalidJs, {compileToEs5: true, softSyntaxError: true}),
+          invalidJs);
+    });
+  });
+
   suite('exponentiation', () => {
     const js = 'const foo = 2**2;';
 


### PR DESCRIPTION
- Expose `htmlTransform` from main package index.

- AMD loader will now only be injected into an HTML document if it contains at least one `type=module` script.

- Added `softParseError` option to `jsTransform`. If set, Babel parse errors will no longer throw. Instead, a console error will be logged, and the original JS returned.

- Prepare `3.0.0-pre.5` release.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
