### PR TITLE
Integrate AMD + module bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5892,9 +5892,9 @@
       }
     },
     "polymer-bundler": {
-      "version": "4.0.0-pre.3",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.0-pre.3.tgz",
-      "integrity": "sha512-XbwHn00+hTRDIYRiveXbGJbOYhySp1x3uVqnIcSrp/9HnKaP6m2j/+3C2IZe2hgLlIWZcKMCl2h5piNy0B52JQ==",
+      "version": "4.0.0-pre.4",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.0-pre.4.tgz",
+      "integrity": "sha512-+xTbJUPrn9Ns5su8W6knfRzqNncJXVncxkjFf0aGCh6vMHFq/Nh+URIAXQnGLJMjkfvUz9qpjp+hDS0oqb4WRg==",
       "requires": {
         "@types/acorn": "4.0.3",
         "@types/babel-generator": "6.25.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "parse5": "^4.0.0",
     "plylog": "^0.5.0",
     "polymer-analyzer": "=3.0.0-pre.18",
-    "polymer-bundler": "^4.0.0-pre.3",
+    "polymer-bundler": "^4.0.0-pre.4",
     "polymer-project-config": "^3.10.0",
     "stream": "0.0.2",
     "sw-precache": "^5.1.1",

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -136,6 +136,10 @@ export class BuildAnalyzer {
       // TODO(usergenic): Add option to polymer-build to propagate a protocol
       // and host option to the FsUrlResolver.
       urlResolver: new FsUrlResolver(config.root),
+
+      moduleResolution: config.moduleResolution === 'none' ?
+          undefined :
+          config.moduleResolution,
     });
 
     this.allFragmentsToAnalyze =

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -13,7 +13,6 @@
  */
 
 import File = require('vinyl');
-import * as parse5 from 'parse5';
 import {ResolvedUrl} from 'polymer-analyzer';
 import {Bundler, Options, BundleManifest, generateShellMergeStrategy} from 'polymer-bundler';
 import {ProjectConfig} from 'polymer-project-config';
@@ -112,7 +111,7 @@ export class BuildBundler extends AsyncTransformStream<File, File> {
         path: pathFromUrl(
             this.config.root as LocalFsPath,
             this._bundler.analyzer.urlResolver.relative(url)),
-        contents: new Buffer(parse5.serialize(document.ast)),
+        contents: new Buffer(document.content),
       }));
     }
   }
@@ -152,11 +151,17 @@ export class BuildBundler extends AsyncTransformStream<File, File> {
    * Removes all of the inlined files in a bundle manifest from the filemap.
    */
   private _unmapBundledFiles(manifest: BundleManifest) {
-    for (const {inlinedHtmlImports,
-                inlinedScripts,
-                inlinedStyles} of manifest.bundles.values()) {
-      for (const url of
-               [...inlinedHtmlImports, ...inlinedScripts, ...inlinedStyles]) {
+    for (const {
+           inlinedHtmlImports,
+           inlinedScripts,
+           inlinedStyles,
+           bundledExports,
+         } of manifest.bundles.values()) {
+      for (const url
+               of [...inlinedHtmlImports,
+                   ...inlinedScripts,
+                   ...inlinedStyles,
+                   ...bundledExports.keys()]) {
         this.files.delete(url);
       }
     }

--- a/src/optimize-streams.ts
+++ b/src/optimize-streams.ts
@@ -215,7 +215,7 @@ export function getOptimizeStreams(options?: OptimizeOptions):
   return streams;
 }
 
-function matchesExt(extension: string) {
+export function matchesExt(extension: string) {
   return (fs: vinyl) => !!fs.path && fs.relative.endsWith(extension);
 }
 


### PR DESCRIPTION
A few fixes to get ES module bundling integrated into polymer-build.

- Write out generated JS bundles. Previously we were receiving parse5 ASTs and calling serialize on them, which produced nothing for JS bundles. Now we receive the JS or or HTML source directly.
- Delete JS files that have been placed into a bundle.
- Pass `moduleResolution` down to the build analyzer.
- Export the `matchesExt` function, CLI will need it in an upcoming PR.